### PR TITLE
Refactor: Make frontend URL for CORS configurable

### DIFF
--- a/README
+++ b/README
@@ -98,6 +98,7 @@ DATABASE_NAME	Name of the MySQL database (default: classerize).
 JWT_SECRET	Secret key for signing JWT tokens.
 LMS_API_BASE_URL	Base URL for LMS API (e.g., Canvas).
 LMS_ACCESS_TOKEN	Access token for LMS API integration.
+FRONTEND_URL	URL of the frontend application, used for CORS configuration (default: http://localhost:3001).
 API Endpoints
 User Routes
 POST /api/auth/register: Register a new user.

--- a/app.js
+++ b/app.js
@@ -10,9 +10,12 @@ const app = express();
 // Middleware
 app.use(express.json());
 app.use(cookieParser());
+
+const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:3001';
+
 app.use(cors({
-    origin: 'http://localhost:3001', // Frontend URL
-    credentials: true, // Allow cookies and credentials
+    origin: FRONTEND_URL,
+    credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization'],
 }));


### PR DESCRIPTION
I modified app.js to use the FRONTEND_URL environment variable for the CORS origin. This allows you flexibility in specifying the frontend URL for different environments (development, staging, production). If the FRONTEND_URL variable is not set, it defaults to 'http://localhost:3001'.

I also updated README.md to include FRONTEND_URL in the list of environment variables with a description of its purpose.